### PR TITLE
Feat: 비즈니스 로직을 재사용하기 위해 Custom hook인 useProducts 구현

### DIFF
--- a/src/components/CartProduct.jsx
+++ b/src/components/CartProduct.jsx
@@ -24,7 +24,6 @@ export default function CartProduct({
             preCount > 1 && --preCount;
         }
         setCountVal(preCount);
-        console.log(preCount);
         updateCount({ uid, id, count: preCount, item });
     };
 

--- a/src/components/Products.jsx
+++ b/src/components/Products.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { getProdcuts } from '../api/firebase';
+import useProducts from '../hooks/useProducts';
 import ProductCard from './ProductCard';
-import { useQuery } from '@tanstack/react-query';
 
 export default function Products() {
     const {
-        isLoading,
-        error,
-        data: products,
-    } = useQuery(['products'], () => getProdcuts().then(data => data), {
-        staleTime: 1000 * 60 * 10,
-    });
+        getProductsQuery: { isLoading, error, data: products },
+    } = useProducts();
 
     if (isLoading) return <p>로딩중 ...</p>;
     if (error) return <p>Error : {error}</p>;

--- a/src/hooks/useProducts.jsx
+++ b/src/hooks/useProducts.jsx
@@ -1,0 +1,24 @@
+import { addProduct as fetchProduct, getProdcuts } from '../api/firebase';
+import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
+
+export default function useProducts() {
+    const queryClient = useQueryClient();
+
+    const getProductsQuery = useQuery(
+        ['products'],
+        () => getProdcuts().then(data => data),
+        {
+            staleTime: 1000 * 60 * 10,
+        }
+    );
+
+    const addProducts = useMutation(
+        //
+        ({ datas, imgURL }) => fetchProduct({ datas, imgURL }),
+        {
+            onSuccess: () => queryClient.invalidateQueries(['products']),
+        }
+    );
+
+    return { getProductsQuery, addProducts };
+}

--- a/src/pages/NewProducts.jsx
+++ b/src/pages/NewProducts.jsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { addCloudinaryImg } from '../api/cloudinary';
-import { addProduct } from '../api/firebase';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import useProducts from '../hooks/useProducts';
 
 export default function NewProducts() {
     const [image, setImage] = useState('');
     const [datas, setDatas] = useState({});
     const [success, setSuccess] = useState(false);
     const [imgError, setImgError] = useState(true);
+    const { addProducts } = useProducts();
 
     const handleAddFile = e => {
         setImgError(false);
@@ -29,14 +30,19 @@ export default function NewProducts() {
 
     const handleSubmit = async e => {
         e.preventDefault();
-        const imgURL = await addCloudinaryImg(image).then(result => result);
-        imgURL &&
-            addProduct({ datas, imgURL }).then(() => {
-                setSuccess('제품을 성공적으로 추가하였습니다.');
-                setTimeout(() => {
-                    setSuccess(false);
-                }, 4000);
-            });
+        addCloudinaryImg(image).then(imgURL =>
+            addProducts.mutate(
+                { datas, imgURL },
+                {
+                    onSuccess: () => {
+                        setSuccess('제품을 성공적으로 추가하였습니다.');
+                        setTimeout(() => {
+                            setSuccess(false);
+                        }, 4000);
+                    },
+                }
+            )
+        );
     };
 
     return (


### PR DESCRIPTION
제품에 관한 데이터를 사용하는 Products, NewProduct컴포넌트들의 비즈니스 로직을 useProducts란 커스텀 훅을 생성하여 구현

    - src/hooks를 생성하여 커스텀훅 useProducts생성
    - useProducts에서 react-Query의 useQueryClient, useQuery, useMutation을 추가
    - firebase DB의 products를 조회하는 useQuery로직을 재사용하기 위해 getProductQuery를 생성
    - firebase DB의 products에 새로운 제품을 추가하는 로직을 재사용하기 위해 useMutation을 이용하여 addProducts생성
    - 서버에 값이 업데이트될때 App과 서버를 동기화 해주기 위해 useMutation을 사용하고 서버 업데이트 성공시 queryClient.invalidateQureies메소드를 통해 기존 product 쿼리캐시 무효화 구현
    - Products와 NewProducts에서 useProducts를 이용하여 firebase DB의 product에 관한 비즈니스 로직을 정리